### PR TITLE
Fix old-style backtick in bbdb/mh-cache-key for Emacs > 23

### DIFF
--- a/lisp/bbdb-mhe.el
+++ b/lisp/bbdb-mhe.el
@@ -33,20 +33,37 @@
 
 (defmacro bbdb/mh-cache-key (message)
   "Return a (numeric) key for MESSAGE"
-  (`(let* ((attrs (file-attributes (, message)))
-           (status-time (nth 6 attrs))
-           (status-time-2 (cdr status-time))
-           (inode (nth 10 attrs)))
-      (logxor (if (integerp inode) ;; if inode is larger than an emacs int,
-                  inode               ;; it's returned as a dotted pair
-                (car inode))
-              (car status-time)
-              ;; We need the following test because XEmacs returns the
-              ;; status time as a dotted pair, whereas FSF and Epoch
-              ;; return it as list.
-              (if (integerp status-time-2)
-                  status-time-2
-                (car status-time-2))))))
+  (if (> emacs-major-version 23)
+    ;; New-style backticks
+    `(let* ((attrs (file-attributes , message))
+	     (status-time (nth 6 attrs))
+	     (status-time-2 (cdr status-time))
+	     (inode (nth 10 attrs)))
+	(logxor (if (integerp inode) ;; if inode is larger than an emacs int,
+		    inode               ;; it's returned as a dotted pair
+		  (car inode))
+		(car status-time)
+		;; We need the following test because XEmacs returns the
+		;; status time as a dotted pair, whereas FSF and Epoch
+		;; return it as list.
+		(if (integerp status-time-2)
+		    status-time-2
+		  (car status-time-2))))
+    ;; Old-style backticks
+    (`(let* ((attrs (file-attributes (, message)))
+	     (status-time (nth 6 attrs))
+	     (status-time-2 (cdr status-time))
+	     (inode (nth 10 attrs)))
+	(logxor (if (integerp inode) ;; if inode is larger than an emacs int,
+		    inode               ;; it's returned as a dotted pair
+		  (car inode))
+		(car status-time)
+		;; We need the following test because XEmacs returns the
+		;; status time as a dotted pair, whereas FSF and Epoch
+		;; return it as list.
+		(if (integerp status-time-2)
+		    status-time-2
+		  (car status-time-2)))))))
 
 ;;;###autoload
 (defun bbdb/mh-update-record (&optional offer-to-create)


### PR DESCRIPTION
This isn't a wholesale refactoring of the macro, rather an option for allowing Emacs >= 24 to use bbdb-insinuate-mh.
