### PR TITLE
Use secure URI in Vcs-Browser control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+bbdb (2.36-5) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs-Browser control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Wed, 12 Sep 2018 03:36:57 +0100
+
 bbdb (2.36-4) unstable; urgency=medium
 
   * engage dh autoreconf, rm ./configure, relax regarding ./configure +x bit

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Build-Depends-Indep: texinfo, texi2html, ghostscript,
     emacs24-nox | emacs24 | emacs23-nox | emacs23 | emacs
 Standards-Version: 3.9.5
 Vcs-Git: https://github.com/barak/BBDB.git
-Vcs-Browser: http://github.com/barak/BBDB
+Vcs-Browser: https://github.com/barak/BBDB
 Homepage: http://bbdb.sourceforge.net/
 
 Package: bbdb


### PR DESCRIPTION
Use secure URI in Vcs-Browser control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
